### PR TITLE
【マークアップ】ユーザー新規登録/ログインページ

### DIFF
--- a/README.md
+++ b/README.md
@@ -164,14 +164,3 @@
 ### Association
 - belongs_to: user
 - belongs_to: product
-
-# git push確認用
-
-
-下に自分の名前を追記してmasterブランチへpush
-
-* 南條孝太朗
-* 門脇光志
-* 岡安海渡
-* 柏木翔大
-* 坂本紗也華

--- a/app/assets/javascripts/profile.js
+++ b/app/assets/javascripts/profile.js
@@ -1,0 +1,30 @@
+$(function() {
+  const CLASS_SELECT_YEAR = '.signup-form__select-year'
+  const CLASS_SELECT_MONTH = '.signup-form__select-month'
+  const CLASS_SELECT_DAY = '.signup-form__select-day'
+
+  function isValidDate(y, m, d) {
+    let dt = new Date(y, m-1, d);
+    return(dt.getFullYear() == y && dt.getMonth() == m-1 && dt.getDate() == d);
+  }
+
+  function set_birthday_selectbox() {
+    let birth_year = Number($(CLASS_SELECT_YEAR).val());
+    let birth_month = Number($(CLASS_SELECT_MONTH).val());
+    
+    if (isValidDate(birth_year, birth_month, 1)) {
+      let birth_month_last_day = new Date(birth_year, birth_month, 0).getDate();
+      let birth_month_days = [...Array(birth_month_last_day).keys()].map(i => ++i);
+
+      $(CLASS_SELECT_DAY).empty();
+      $(CLASS_SELECT_DAY).append(`<option>--</option>`)
+
+      birth_month_days.forEach(function(day) {
+        $(CLASS_SELECT_DAY).append(`<option value='${day}'>${day}</option>`);
+      });
+    }
+  }
+
+  $(CLASS_SELECT_YEAR).on('change', set_birthday_selectbox);
+  $(CLASS_SELECT_MONTH).on('change', set_birthday_selectbox);
+});

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -2,3 +2,4 @@
 @import "font-awesome-sprockets";
 @import "font-awesome";
 @import "products";
+@import "signup";

--- a/app/assets/stylesheets/signup.scss
+++ b/app/assets/stylesheets/signup.scss
@@ -1,18 +1,20 @@
 $wallpaper_color: #FAFAFA;
 $disabled_color:  #AAAAAA;
 $completed_color: #3CCACE;
+$header_width: 700px;
+$header_height: 150px;
+$content_width: 700px;
+$form_width: 300px;
 
-html {
+.signup-container {
+  width: 100vw;
   background-color: $wallpaper_color;
 }
 
-.signup-container {
-  width: 700px;
-  margin: 0 auto;
-}
-
 .signup-header {
-  height: 150px;
+  width: $header_width;
+  height: $header_height;
+  margin: 0 auto;
   display: flex;
   justify-content: space-evenly;
   align-items: center;
@@ -102,7 +104,9 @@ html {
 }
 
 .signup-content {
-  background-color: #fff;
+  width: $content_width;
+  margin: 0 auto;
+  background-color: white;
   padding: 24px 0;
 }
 
@@ -116,7 +120,7 @@ html {
 
 .signup-form {
   &__field, &__actions {
-    width: 300px;
+    width: $form_width;
     margin: 24px auto;
   }
   %__label {
@@ -140,13 +144,30 @@ html {
       }
     }
   }
-  &__text-field, &__email-field, &__password-field {
+  &__birthdate-field {
     width: 100%;
+    display: flex;
+    justify-content: space-between;
+    align-items: flex-end;
+  }
+  %__input-field {
     height: 48px;
     padding: 0 8px;
     line-height: 48px;
     border: 1px solid #AAAAAA;
     border-radius: 4px;
+  }
+  &__text-field, &__email-field, &__password-field {
+    @extend %__input-field;
+    width: $form_width;
+  }
+  &__select-year {
+    @extend %__input-field;
+    width: calc(#{$form_width} * 0.3);
+  }
+  &__select-month, &__select-day {
+    @extend %__input-field;
+    width: calc(#{$form_width} * 0.25);
   }
   &__submit {
     width: 100%;
@@ -157,5 +178,9 @@ html {
     text-align: center;
     border-width: 0;
     cursor: pointer;
+  }
+
+  .error-messages {
+    color: red;
   }
 }

--- a/app/assets/stylesheets/signup.scss
+++ b/app/assets/stylesheets/signup.scss
@@ -1,0 +1,161 @@
+$wallpaper_color: #FAFAFA;
+$disabled_color:  #AAAAAA;
+$completed_color: #3CCACE;
+
+html {
+  background-color: $wallpaper_color;
+}
+
+.signup-container {
+  width: 700px;
+  margin: 0 auto;
+}
+
+.signup-header {
+  height: 150px;
+  display: flex;
+  justify-content: space-evenly;
+  align-items: center;
+  &__logo:hover {
+    opacity: 0.5;
+  }
+}
+
+.progress-bar {
+  display: flex;
+  margin: 0 0 1rem 0;
+  justify-content: space-between;
+  %__item {
+    flex: 2;
+    width: 80px;
+    position: relative;
+    padding: 0 0 14px 0;
+    font-size: 12px;
+    line-height: 1.5;
+    font-weight: 600;
+    white-space: nowrap;
+    overflow: visible;
+    min-width: 0;
+    text-align: center;
+    border-bottom: 2px solid $disabled_color;
+    &:first-child {
+      flex: 1;
+      &:before {
+        left: 0;
+      }
+    }
+    &:last-child {
+      flex: 1;
+      text-align: right;
+      &:before {
+        right: 0;
+        left: auto;
+      }
+    }
+    &:before {
+      content: "";
+      display: block;
+      width: 8px;
+      height: 8px;
+      border-radius: 50%;
+      position: absolute;
+      left: calc(50% - 7px);
+      bottom: -7px;
+      z-index: 3;
+      transition: all .2s ease-in-out;
+    }
+  }
+  &__item {
+    @extend %__item;
+    color: $disabled_color;
+    &:before {
+      background-color: $disabled_color;
+      border: 2px solid $wallpaper_color;
+    }
+    &--complete, &--active {
+      @extend %__item;
+      color: $completed_color;
+      &:not(:first-child):after {
+        content: "";
+        display: block;
+        width: 100%;
+        position: absolute;
+        bottom: -2px;
+        left: -50%;
+        z-index: 2;
+        border-bottom: 2px solid $completed_color;
+      }
+      &:last-child:after {
+        width: 200%;
+        left: -100%;
+      }
+    }
+    &--complete:before {
+      background-color: $completed_color;
+      border: 2px solid $wallpaper_color;
+    }
+    &--active:before {
+      background-color: white;
+      border: 2px solid $completed_color;
+    }
+  }
+}
+
+.signup-content {
+  background-color: #fff;
+  padding: 24px 0;
+}
+
+.signup-title {
+  padding: 32px 0;
+  font-size: 24px;
+  font-weight: 600;
+  text-align: center;
+  border-bottom: 1px solid #EEEEEE;
+}
+
+.signup-form {
+  &__field, &__actions {
+    width: 300px;
+    margin: 24px auto;
+  }
+  %__label {
+    display: block;
+    margin-bottom: 4px;
+    font-size: 14px;
+    font-weight: 600;
+  }
+  &__label {
+    @extend %__label;
+    &--required {
+      @extend %__label;
+      &:after {
+        content: "必須";
+        font-size: 10px;
+        color: white;
+        background-color: $completed_color;
+        margin-left: 8px;
+        padding: 4px;
+        border-radius: 2px;
+      }
+    }
+  }
+  &__text-field, &__email-field, &__password-field {
+    width: 100%;
+    height: 48px;
+    padding: 0 8px;
+    line-height: 48px;
+    border: 1px solid #AAAAAA;
+    border-radius: 4px;
+  }
+  &__submit {
+    width: 100%;
+    height: 48px;
+    background-color: $completed_color;
+    color: white;
+    line-height: 48px;
+    text-align: center;
+    border-width: 0;
+    cursor: pointer;
+  }
+}

--- a/app/assets/stylesheets/signup.scss
+++ b/app/assets/stylesheets/signup.scss
@@ -1,19 +1,21 @@
-$wallpaper_color: #FAFAFA;
-$disabled_color:  #AAAAAA;
-$completed_color: #3CCACE;
-$header_width: 700px;
-$header_height: 150px;
-$content_width: 700px;
-$form_width: 300px;
+$signup_wallpaper_color: #FAFAFA;
+$signup_disagled_color:  #AAAAAA;
+$signup_completed_color: #3CCACE;
+$signup_header_width: 700px;
+$signup_header_height: 150px;
+$signup_content_width: 700px;
+$signup_form_width: 300px;
 
 .signup-container {
   width: 100vw;
-  background-color: $wallpaper_color;
+  height: 100vh;
+  background-color: $signup_wallpaper_color;
+  overflow: scroll;
 }
 
 .signup-header {
-  width: $header_width;
-  height: $header_height;
+  width: $signup_header_width;
+  height: $signup_header_height;
   margin: 0 auto;
   display: flex;
   justify-content: space-evenly;
@@ -39,7 +41,7 @@ $form_width: 300px;
     overflow: visible;
     min-width: 0;
     text-align: center;
-    border-bottom: 2px solid $disabled_color;
+    border-bottom: 2px solid $signup_disagled_color;
     &:first-child {
       flex: 1;
       &:before {
@@ -69,14 +71,14 @@ $form_width: 300px;
   }
   &__item {
     @extend %__item;
-    color: $disabled_color;
+    color: $signup_disagled_color;
     &:before {
-      background-color: $disabled_color;
-      border: 2px solid $wallpaper_color;
+      background-color: $signup_disagled_color;
+      border: 2px solid $signup_wallpaper_color;
     }
     &--complete, &--active {
       @extend %__item;
-      color: $completed_color;
+      color: $signup_completed_color;
       &:not(:first-child):after {
         content: "";
         display: block;
@@ -85,7 +87,7 @@ $form_width: 300px;
         bottom: -2px;
         left: -50%;
         z-index: 2;
-        border-bottom: 2px solid $completed_color;
+        border-bottom: 2px solid $signup_completed_color;
       }
       &:last-child:after {
         width: 200%;
@@ -93,18 +95,18 @@ $form_width: 300px;
       }
     }
     &--complete:before {
-      background-color: $completed_color;
-      border: 2px solid $wallpaper_color;
+      background-color: $signup_completed_color;
+      border: 2px solid $signup_wallpaper_color;
     }
     &--active:before {
       background-color: white;
-      border: 2px solid $completed_color;
+      border: 2px solid $signup_completed_color;
     }
   }
 }
 
 .signup-content {
-  width: $content_width;
+  width: $signup_content_width;
   margin: 0 auto;
   background-color: white;
   padding: 24px 0;
@@ -120,8 +122,15 @@ $form_width: 300px;
 
 .signup-form {
   &__field, &__actions {
-    width: $form_width;
+    width: $signup_form_width;
     margin: 24px auto;
+  }
+  &__container {
+    display: flex;
+    justify-content: space-between;
+  }
+  &__postcode-field, &__prefecture-field {
+    width: 48%;
   }
   %__label {
     display: block;
@@ -137,7 +146,7 @@ $form_width: 300px;
         content: "必須";
         font-size: 10px;
         color: white;
-        background-color: $completed_color;
+        background-color: $signup_completed_color;
         margin-left: 8px;
         padding: 4px;
         border-radius: 2px;
@@ -145,7 +154,7 @@ $form_width: 300px;
     }
   }
   &__birthdate-field {
-    width: 100%;
+    width: $signup_form_width;
     display: flex;
     justify-content: space-between;
     align-items: flex-end;
@@ -159,28 +168,65 @@ $form_width: 300px;
   }
   &__text-field, &__email-field, &__password-field {
     @extend %__input-field;
-    width: $form_width;
+    width: 100%;
   }
   &__select-year {
     @extend %__input-field;
-    width: calc(#{$form_width} * 0.3);
+    width: calc(#{$signup_form_width} * 0.3);
   }
   &__select-month, &__select-day {
     @extend %__input-field;
-    width: calc(#{$form_width} * 0.25);
+    width: calc(#{$signup_form_width} * 0.25);
+  }
+  &__select-postcode, &__select-prefecture {
+    @extend %__input-field;
+    width: 100%;
   }
   &__submit {
     width: 100%;
     height: 48px;
-    background-color: $completed_color;
+    background-color: $signup_completed_color;
     color: white;
     line-height: 48px;
     text-align: center;
     border-width: 0;
     cursor: pointer;
   }
-
-  .error-messages {
+  &__checkbox-field {
+    display: flex;
+    justify-content: flex-start;
+    align-items: flex-start;
+  }
+  &__checkbox {
+    width: 16px;
+    height: 16px;
+    margin: 2px;
+  }
+  &__error-messages {
     color: red;
+    text-align: center;
+  }
+}
+
+.error-messages {
+  color: red;
+}
+
+.registration {
+  text-align: center;
+  font-size: 14px;
+  width: $signup_content_width;
+  padding-bottom: 24px;
+  margin-bottom: 16px;
+  border-bottom: 1px solid #EEEEEE;
+  &__button {
+    width: $signup_form_width;
+    height: 48px;
+    background-color: #33aaff;
+    color: white;
+    line-height: 48px;
+    text-align: center;
+    display: block;
+    margin: 0 auto;
   }
 }

--- a/app/views/devise/registrations/_error_messages.html.haml
+++ b/app/views/devise/registrations/_error_messages.html.haml
@@ -1,6 +1,0 @@
-- if model.errors[target].any?
-  %ul.error-messages
-    - model.errors[target].each do |message|
-      %li.error-messages__item
-        = I18n.t target, scope: [:activerecord, :attributes, scope]
-        = message

--- a/app/views/devise/registrations/_error_messages.html.haml
+++ b/app/views/devise/registrations/_error_messages.html.haml
@@ -1,0 +1,6 @@
+- if model.errors[target].any?
+  %ul.error-messages
+    - model.errors[target].each do |message|
+      %li.error-messages__item
+        = I18n.t target, scope: [:activerecord, :attributes, scope]
+        = message

--- a/app/views/devise/registrations/_progress.html.haml
+++ b/app/views/devise/registrations/_progress.html.haml
@@ -1,0 +1,11 @@
+%ol.progress-bar
+  - ['会員情報', 'プロフィール', '送付先住所', '完了'].each_with_index do |item, index|
+    - if progress < index
+      %li.progress-bar__item
+        = content_tag(:span, item)
+    - elsif progress == index
+      %li.progress-bar__item--active
+        = content_tag(:span, item)
+    - else
+      %li.progress-bar__item--complete
+        = content_tag(:span, item) 

--- a/app/views/devise/registrations/_progress.html.haml
+++ b/app/views/devise/registrations/_progress.html.haml
@@ -1,5 +1,5 @@
 %ol.progress-bar
-  - ['会員情報', 'プロフィール', '送付先住所', '完了'].each_with_index do |item, index|
+  - ['会員情報', 'プロフィール', '送付先住所'].each_with_index do |item, index|
     - if progress < index
       %li.progress-bar__item
         = content_tag(:span, item)

--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -1,25 +1,27 @@
-%h2 Sign up(1/3)
-= form_for(@user, url: user_registration_path) do |f|
-  = render "devise/shared/error_messages", resource: @user
-  .field
-    = f.label :nickname
-    %br/
-    = f.text_field :nickname
-  .field
-    = f.label :email
-    %br/
-    = f.email_field :email, autofocus: true, autocomplete: "email"
-  .field
-    = f.label :password
-    - if @minimum_password_length
-      %em
-        (#{@minimum_password_length} characters minimum)
-    %br/
-    = f.password_field :password, autocomplete: "new-password"
-  .field
-    = f.label :password_confirmation
-    %br/
-    = f.password_field :password_confirmation, autocomplete: "new-password"
-  .actions
-    = f.submit "Next"
-= render "devise/shared/links"
+.signup-container
+  %header.signup-header
+    %h1
+      = link_to root_path, class: 'signup-header__logo' do
+        = image_tag 'logo.png', size: '140x40', alt: 'ロゴ'
+    = render partial: 'progress', locals: { progress: 0 }
+
+  .signup-content
+    %h2.signup-title 会員情報入力
+    = form_for(@user, url: user_registration_path, html: { class: 'signup-form' }) do |f|
+      = render "devise/shared/error_messages", resource: @user
+      .signup-form__field
+        = f.label :nickname, class: 'signup-form__label--required'
+        = f.text_field :nickname, autofocus: true, placeholder: '例) フリマ次郎', class: 'signup-form__text-field'
+      .signup-form__field
+        = f.label :email, class: 'signup-form__label--required'
+        = f.email_field :email, autocomplete: 'email', placeholder: 'PC・携帯どちらでも可', class: 'signup-form__email-field'
+      .signup-form__field
+        = f.label :password, class: 'signup-form__label--required'
+        = f.password_field :password, autocomplete: 'new-password', placeholder: "#{@minimum_password_length}文字以上", class: 'signup-form__password-field'
+      .signup-form__field
+        = f.label :password_confirmation, class: 'signup-form__label--required'
+        = f.password_field :password_confirmation, autocomplete: 'new-password', placeholder: "#{@minimum_password_length}文字以上", class: 'signup-form__password-field'
+      .signup-form__actions
+        = f.submit '次へ進む', class: 'signup-form__submit'
+    -# = render "devise/shared/links"
+

--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -8,20 +8,23 @@
   .signup-content
     %h2.signup-title 会員情報入力
     = form_for(@user, url: user_registration_path, html: { class: 'signup-form' }) do |f|
-      = render "devise/shared/error_messages", resource: @user
       .signup-form__field
         = f.label :nickname, class: 'signup-form__label--required'
         = f.text_field :nickname, autofocus: true, placeholder: '例) フリマ次郎', class: 'signup-form__text-field'
+        = render partial: 'error_messages', locals: { model: @user, scope: :user, target: :nickname }
       .signup-form__field
         = f.label :email, class: 'signup-form__label--required'
         = f.email_field :email, autocomplete: 'email', placeholder: 'PC・携帯どちらでも可', class: 'signup-form__email-field'
+        = render partial: 'error_messages', locals: { model: @user, scope: :user, target: :email }
       .signup-form__field
         = f.label :password, class: 'signup-form__label--required'
         = f.password_field :password, autocomplete: 'new-password', placeholder: "#{@minimum_password_length}文字以上", class: 'signup-form__password-field'
+        = render partial: 'error_messages', locals: { model: @user, scope: :user, target: :password }
       .signup-form__field
         = f.label :password_confirmation, class: 'signup-form__label--required'
         = f.password_field :password_confirmation, autocomplete: 'new-password', placeholder: "#{@minimum_password_length}文字以上", class: 'signup-form__password-field'
+        = render partial: 'error_messages', locals: { model: @user, scope: :user, target: :password_confirmation }
       .signup-form__actions
         = f.submit '次へ進む', class: 'signup-form__submit'
-    -# = render "devise/shared/links"
+
 

--- a/app/views/devise/registrations/new.html.haml
+++ b/app/views/devise/registrations/new.html.haml
@@ -11,19 +11,19 @@
       .signup-form__field
         = f.label :nickname, class: 'signup-form__label--required'
         = f.text_field :nickname, autofocus: true, placeholder: '例) フリマ次郎', class: 'signup-form__text-field'
-        = render partial: 'error_messages', locals: { model: @user, scope: :user, target: :nickname }
+        = render partial: 'devise/shared/error_messages', locals: { model: @user, scope: :user, target: :nickname }
       .signup-form__field
         = f.label :email, class: 'signup-form__label--required'
         = f.email_field :email, autocomplete: 'email', placeholder: 'PC・携帯どちらでも可', class: 'signup-form__email-field'
-        = render partial: 'error_messages', locals: { model: @user, scope: :user, target: :email }
+        = render partial: 'devise/shared/error_messages', locals: { model: @user, scope: :user, target: :email }
       .signup-form__field
         = f.label :password, class: 'signup-form__label--required'
         = f.password_field :password, autocomplete: 'new-password', placeholder: "#{@minimum_password_length}文字以上", class: 'signup-form__password-field'
-        = render partial: 'error_messages', locals: { model: @user, scope: :user, target: :password }
+        = render partial: 'devise/shared/error_messages', locals: { model: @user, scope: :user, target: :password }
       .signup-form__field
         = f.label :password_confirmation, class: 'signup-form__label--required'
         = f.password_field :password_confirmation, autocomplete: 'new-password', placeholder: "#{@minimum_password_length}文字以上", class: 'signup-form__password-field'
-        = render partial: 'error_messages', locals: { model: @user, scope: :user, target: :password_confirmation }
+        = render partial: 'devise/shared/error_messages', locals: { model: @user, scope: :user, target: :password_confirmation }
       .signup-form__actions
         = f.submit '次へ進む', class: 'signup-form__submit'
 

--- a/app/views/devise/registrations/new_address.html.haml
+++ b/app/views/devise/registrations/new_address.html.haml
@@ -1,45 +1,54 @@
-%h2 Sign up(3/3)
-= form_for @address do |f|
-  = render "devise/shared/error_messages", resource: @address
-  .field
-    = f.label :address_family_name
-    %br/
-    = f.text_field :address_family_name
-  .field
-    = f.label :address_first_name
-    %br/
-    = f.text_field :address_first_name
-  .field
-    = f.label :address_family_name_kana
-    %br/
-    = f.text_field :address_family_name_kana
-  .field
-    = f.label :address_first_name_kana
-    %br/
-    = f.text_field :address_first_name_kana
-  .field
-    = f.label :post_code
-    %br/
-    = f.text_field :post_code
-  .field
-    = f.label :prefecture
-    %br/
-    = f.text_field :prefecture
-  .field
-    = f.label :city
-    %br/
-    = f.text_field :city
-  .field
-    = f.label :address_number
-    %br/
-    = f.text_field :address_number
-  .field
-    = f.label :building_name
-    %br/
-    = f.text_field :building_name
-  .field
-    = f.label :phone_number
-    %br/
-    = f.text_field :phone_number
-  .actions
-    = f.submit "Submit"
+.signup-container
+  %header.signup-header
+    %h1
+      = link_to root_path, class: 'signup-header__logo' do
+        = image_tag 'logo.png', size: '140x40', alt: 'ロゴ'
+    = render partial: 'progress', locals: { progress: 2 }
+
+  .signup-content
+    %h2.signup-title 送付先住所入力
+    = form_for @address, html: { class: 'signup-form' } do |f|
+      .signup-form__field
+        = f.label :address_family_name, class: 'signup-form__label--required'
+        = f.text_field :address_family_name, autofocus: true, placeholder: '例) フリマ', class: 'signup-form__text-field'
+        = render partial: 'devise/shared/error_messages', locals: { model: @address, scope: :shipping_address, target: :address_family_name }
+      .signup-form__field
+        = f.label :address_first_name, class: 'signup-form__label--required'
+        = f.text_field :address_first_name, placeholder: '例) 次郎', class: 'signup-form__text-field'
+        = render partial: 'devise/shared/error_messages', locals: { model: @address, scope: :shipping_address, target: :address_first_name }
+      .signup-form__field
+        = f.label :address_family_name_kana, class: 'signup-form__label--required'
+        = f.text_field :address_family_name_kana, placeholder: '例) ふりま', class: 'signup-form__text-field'
+        = render partial: 'devise/shared/error_messages', locals: { model: @address, scope: :shipping_address, target: :address_family_name_kana }
+      .signup-form__field
+        = f.label :address_first_name_kana, class: 'signup-form__label--required'
+        = f.text_field :address_first_name_kana, placeholder: '例) じろう', class: 'signup-form__text-field'
+        = render partial: 'devise/shared/error_messages', locals: { model: @address, scope: :shipping_address, target: :address_first_name_kana }
+      .signup-form__field
+        .signup-form__container
+          .signup-form__postcode-field
+            = f.label :post_code, class: 'signup-form__label--required'
+            = f.text_field :post_code, placeholder: '7桁数字', class: 'signup-form__text-field'
+          .signup-form__prefecture-field
+            = f.label :prefecture, class: 'signup-form__label--required'
+            = f.select :prefecture, JpPrefecture::Prefecture.all.map{ |data| data.name }, { include_blank: '--' }, class: 'signup-form__select-prefecture'
+        = render partial: 'devise/shared/error_messages', locals: { model: @address, scope: :shipping_address, target: :post_code }
+        = render partial: 'devise/shared/error_messages', locals: { model: @address, scope: :shipping_address, target: :prefecture }
+      .signup-form__field
+        = f.label :city, class: 'signup-form__label--required'
+        = f.text_field :city, placeholder: '例) フリマ市', class: 'signup-form__text-field'
+        = render partial: 'devise/shared/error_messages', locals: { model: @address, scope: :shipping_address, target: :city }
+      .signup-form__field
+        = f.label :address_number, class: 'signup-form__label--required'
+        = f.text_field :address_number, placeholder: '例) 〇〇番地〇〇丁目〇〇号', class: 'signup-form__text-field'
+        = render partial: 'devise/shared/error_messages', locals: { model: @address, scope: :shipping_address, target: :address_number }
+      .signup-form__field
+        = f.label :building_name, class: 'signup-form__label'
+        = f.text_field :building_name, class: 'signup-form__text-field'
+        = render partial: 'devise/shared/error_messages', locals: { model: @address, scope: :shipping_address, target: :building_name }
+      .signup-form__field
+        = f.label :phone_number, class: 'signup-form__label'
+        = f.text_field :phone_number, placeholder: 'ハイフンなし', class: 'signup-form__text-field'
+        = render partial: 'devise/shared/error_messages', locals: { model: @address, scope: :shipping_address, target: :phone_number }
+      .signup-form__actions
+        = f.submit '登録', class: 'signup-form__submit'

--- a/app/views/devise/registrations/new_profile.html.haml
+++ b/app/views/devise/registrations/new_profile.html.haml
@@ -1,34 +1,41 @@
-%h2 Sign up(2/3)
-= form_for @profile do |f|
-  = render "devise/shared/error_messages", resource: @profile
-  .field
-    = f.label :family_name
-    %br/
-    = f.text_field :family_name
-  .field
-    = f.label :first_name
-    %br/
-    = f.text_field :first_name
-  .field
-    = f.label :family_name_kana
-    %br/
-    = f.text_field :family_name_kana
-  .field
-    = f.label :first_name_kana
-    %br/
-    = f.text_field :first_name_kana
-  .field
-    = f.label :birth_year
-    %br/
-    = f.text_field :birth_year
-  .field
-    = f.label :birth_month
-    %br/
-    = f.text_field :birth_month
-  .field
-    = f.label :birth_day
-    %br/
-    = f.text_field :birth_day
-  
-  .actions
-    = f.submit "Next"
+.signup-container
+  %header.signup-header
+    %h1
+      = link_to root_path, class: 'signup-header__logo' do
+        = image_tag 'logo.png', size: '140x40', alt: 'ロゴ'
+    = render partial: 'progress', locals: { progress: 1 }
+
+  .signup-content
+    %h2.signup-title プロフィール入力
+    = form_for @profile, html: { class: 'signup-form' } do |f|
+      .signup-form__field
+        = f.label :family_name, class: 'signup-form__label--required'
+        = f.text_field :family_name, autofocus: true, placeholder: '例) フリマ', class: 'signup-form__text-field'
+        = render partial: 'error_messages', locals: { model: @profile, scope: :profile, target: :family_name }
+      .signup-form__field
+        = f.label :first_name, class: 'signup-form__label--required'
+        = f.text_field :first_name, placeholder: '例) 次郎', class: 'signup-form__text-field'
+        = render partial: 'error_messages', locals: { model: @profile, scope: :profile, target: :first_name }
+      .signup-form__field
+        = f.label :family_name_kana, class: 'signup-form__label--required'
+        = f.text_field :family_name_kana, placeholder: '例) ふりま', class: 'signup-form__text-field'
+        = render partial: 'error_messages', locals: { model: @profile, scope: :profile, target: :family_name_kana }
+      .signup-form__field
+        = f.label :first_name_kana, class: 'signup-form__label--required'
+        = f.text_field :first_name_kana, placeholder: '例) じろう', class: 'signup-form__text-field'
+        = render partial: 'error_messages', locals: { model: @profile, scope: :profile, target: :first_name_kana }
+      .signup-form__field
+        = f.label :birth_date, class: 'signup-form__label--required'
+        .signup-form__birthdate-field
+          = f.select :birth_year, (1920..Date.today.year).to_a.reverse, { include_blank: '--' }, class: 'signup-form__select-year'
+          年
+          = f.select :birth_month, (1..12).to_a, { include_blank: '--' }, class: 'signup-form__select-month'
+          月
+          = f.select :birth_day, [], { include_blank: '--' }, class: 'signup-form__select-day'
+          日
+        = render partial: 'error_messages', locals: { model: @profile, scope: :profile, target: :birth_date }
+        = render partial: 'error_messages', locals: { model: @profile, scope: :profile, target: :birth_year }
+        = render partial: 'error_messages', locals: { model: @profile, scope: :profile, target: :birth_month }
+        = render partial: 'error_messages', locals: { model: @profile, scope: :profile, target: :birth_day }
+      .signup-form__actions
+        = f.submit "次へ進む", class: 'signup-form__submit'

--- a/app/views/devise/registrations/new_profile.html.haml
+++ b/app/views/devise/registrations/new_profile.html.haml
@@ -11,19 +11,19 @@
       .signup-form__field
         = f.label :family_name, class: 'signup-form__label--required'
         = f.text_field :family_name, autofocus: true, placeholder: '例) フリマ', class: 'signup-form__text-field'
-        = render partial: 'error_messages', locals: { model: @profile, scope: :profile, target: :family_name }
+        = render partial: 'devise/shared/error_messages', locals: { model: @profile, scope: :profile, target: :family_name }
       .signup-form__field
         = f.label :first_name, class: 'signup-form__label--required'
         = f.text_field :first_name, placeholder: '例) 次郎', class: 'signup-form__text-field'
-        = render partial: 'error_messages', locals: { model: @profile, scope: :profile, target: :first_name }
+        = render partial: 'devise/shared/error_messages', locals: { model: @profile, scope: :profile, target: :first_name }
       .signup-form__field
         = f.label :family_name_kana, class: 'signup-form__label--required'
         = f.text_field :family_name_kana, placeholder: '例) ふりま', class: 'signup-form__text-field'
-        = render partial: 'error_messages', locals: { model: @profile, scope: :profile, target: :family_name_kana }
+        = render partial: 'devise/shared/error_messages', locals: { model: @profile, scope: :profile, target: :family_name_kana }
       .signup-form__field
         = f.label :first_name_kana, class: 'signup-form__label--required'
         = f.text_field :first_name_kana, placeholder: '例) じろう', class: 'signup-form__text-field'
-        = render partial: 'error_messages', locals: { model: @profile, scope: :profile, target: :first_name_kana }
+        = render partial: 'devise/shared/error_messages', locals: { model: @profile, scope: :profile, target: :first_name_kana }
       .signup-form__field
         = f.label :birth_date, class: 'signup-form__label--required'
         .signup-form__birthdate-field
@@ -33,9 +33,9 @@
           月
           = f.select :birth_day, [], { include_blank: '--' }, class: 'signup-form__select-day'
           日
-        = render partial: 'error_messages', locals: { model: @profile, scope: :profile, target: :birth_date }
-        = render partial: 'error_messages', locals: { model: @profile, scope: :profile, target: :birth_year }
-        = render partial: 'error_messages', locals: { model: @profile, scope: :profile, target: :birth_month }
-        = render partial: 'error_messages', locals: { model: @profile, scope: :profile, target: :birth_day }
+        = render partial: 'devise/shared/error_messages', locals: { model: @profile, scope: :profile, target: :birth_date }
+        = render partial: 'devise/shared/error_messages', locals: { model: @profile, scope: :profile, target: :birth_year }
+        = render partial: 'devise/shared/error_messages', locals: { model: @profile, scope: :profile, target: :birth_month }
+        = render partial: 'devise/shared/error_messages', locals: { model: @profile, scope: :profile, target: :birth_day }
       .signup-form__actions
         = f.submit "次へ進む", class: 'signup-form__submit'

--- a/app/views/devise/sessions/new.html.haml
+++ b/app/views/devise/sessions/new.html.haml
@@ -1,17 +1,30 @@
-%h2 Log in
-= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f|
-  .field
-    = f.label :email
-    %br/
-    = f.email_field :email, autofocus: true, autocomplete: "email"
-  .field
-    = f.label :password
-    %br/
-    = f.password_field :password, autocomplete: "current-password"
-  - if devise_mapping.rememberable?
-    .field
-      = f.check_box :remember_me
-      = f.label :remember_me
-  .actions
-    = f.submit "Log in"
-= render "devise/shared/links"
+.signup-container
+  %header.signup-header
+    %h1
+      = link_to root_path, class: 'signup-header__logo' do
+        = image_tag 'logo.png', size: '140x40', alt: 'ロゴ'
+
+  .signup-content
+    - if flash[:alert]
+      %p.signup-form__error-messages
+        = flash[:alert]
+
+    .registration
+      %p
+        アカウントをお持ちでない方はこちら
+      = link_to '新規会員登録', new_user_registration_path, class: 'registration__button'
+    = form_for(resource, as: resource_name, url: session_path(resource_name), html: { class: 'signup-form' }) do |f|
+      .signup-form__field
+        = f.label :email, class: 'signup-form__label'
+        = f.email_field :email, autofocus: true, autocomplete: 'email', class: 'signup-form__email-field'
+      .signup-form__field
+        = f.label :password, class: 'signup-form__label'
+        = f.password_field :password, autocomplete: 'current-password', class: 'signup-form__password-field'
+      - if devise_mapping.rememberable?
+        .signup-form__field
+          .signup-form__checkbox-field
+            = f.check_box :remember_me, class: 'signup-form__checkbox'
+            = f.label :remember_me, class: 'signup-form__label'
+      .signup-form__actions
+        = f.submit 'ログイン', class: 'signup-form__submit'
+

--- a/app/views/devise/shared/_error_messages.html.haml
+++ b/app/views/devise/shared/_error_messages.html.haml
@@ -1,9 +1,16 @@
-- if resource.errors.any?
-  #error_explanation
-    %h2
-      = I18n.t("errors.messages.not_saved",                 |
-        count: resource.errors.count,                       |
-        resource: resource.class.model_name.human.downcase) |
-    %ul
-      - resource.errors.full_messages.each do |message|
-        %li= message
+- if model.errors[target].any?
+  %ul.error-messages
+    - model.errors[target].each do |message|
+      %li.error-messages__item
+        = I18n.t target, scope: [:activerecord, :attributes, scope]
+        = message
+
+-# - if resource.errors.any?
+-#   #error_explanation
+-#     %h2
+-#       = I18n.t("errors.messages.not_saved",                 |
+-#         count: resource.errors.count,                       |
+-#         resource: resource.class.model_name.human.downcase) |
+-#     %ul
+-#       - resource.errors.full_messages.each do |message|
+-#         %li= message

--- a/config/locales/models/ja.yml
+++ b/config/locales/models/ja.yml
@@ -17,7 +17,7 @@ ja:
         birth_year: 誕生年
         birth_month: 誕生月
         birth_day: 誕生日
-        birth_date: 誕生年月日
+        birth_date: 生年月日
       shipping_address:
         address_family_name: 姓
         address_first_name: 名

--- a/config/locales/models/ja.yml
+++ b/config/locales/models/ja.yml
@@ -7,6 +7,7 @@ ja:
     attributes:
       user:
         nickname: ニックネーム
+        email: メールアドレス
       profile:
         family_name: 姓
         first_name: 名


### PR DESCRIPTION
# What
- ユーザー新規登録ページ(ウィザード形式)のマークアップおよびフロント実装
- ユーザーログインページのマークアップおよびフロント実装

## Screenshots
### ユーザ登録ページ(1/3)
![localhost_3000_users_sign_up](https://user-images.githubusercontent.com/50756490/79627111-81aadc00-8170-11ea-9922-c7ce7ecb7e60.png)

### ユーザ登録ページ(2/3)
![localhost_3000_users](https://user-images.githubusercontent.com/50756490/79627125-b28b1100-8170-11ea-8651-1cc4fd104ef0.png)

### ユーザ登録ページ(3/3)
![localhost_3000_profiles](https://user-images.githubusercontent.com/50756490/79627140-cfbfdf80-8170-11ea-83ce-1b8ceb96bd0c.png)

### ログインページ
![localhost_3000_profiles (1)](https://user-images.githubusercontent.com/50756490/79627148-ebc38100-8170-11ea-9524-6ea177376498.png)

# Why
- 新規実装
- サービスの基本機能であるため
