### PR TITLE
categoryモデルのアソシエーション修正

### DIFF
--- a/app/models/card.rb
+++ b/app/models/card.rb
@@ -5,9 +5,17 @@
 #  id          :integer          not null, primary key
 #  created_at  :datetime         not null
 #  updated_at  :datetime         not null
-#  card_id     :string(255)
-#  customer_id :string(255)
-#  user_id     :integer
+#  card_id     :string(255)      not null
+#  customer_id :string(255)      not null
+#  user_id     :integer          not null
+#
+# Indexes
+#
+#  index_cards_on_user_id  (user_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (user_id => users.id)
 #
 class Card < ApplicationRecord
   belongs_to :user

--- a/app/models/category.rb
+++ b/app/models/category.rb
@@ -19,6 +19,6 @@ class Category < ApplicationRecord
   has_many :category_sizes, dependent: :destroy
   
   # 自己結合モデル
-  belongs_to :parent, class_name: :Category  
+  belongs_to :parent, class_name: :Category, optional: true
   has_many :children, class_name: :Category, foreign_key: :ancestry
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -13,11 +13,12 @@
 ActiveRecord::Schema.define(version: 20200418033847) do
 
   create_table "cards", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
-    t.integer  "user_id"
-    t.string   "customer_id"
-    t.string   "card_id"
+    t.integer  "user_id",     null: false
+    t.string   "customer_id", null: false
+    t.string   "card_id",     null: false
     t.datetime "created_at",  null: false
     t.datetime "updated_at",  null: false
+    t.index ["user_id"], name: "index_cards_on_user_id", using: :btree
   end
 
   create_table "categories", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
@@ -129,6 +130,7 @@ ActiveRecord::Schema.define(version: 20200418033847) do
     t.index ["reset_password_token"], name: "index_users_on_reset_password_token", unique: true, using: :btree
   end
 
+  add_foreign_key "cards", "users"
   add_foreign_key "category_sizes", "categories"
   add_foreign_key "category_sizes", "sizes"
   add_foreign_key "orders", "products"

--- a/spec/factories/cards.rb
+++ b/spec/factories/cards.rb
@@ -5,9 +5,17 @@
 #  id          :integer          not null, primary key
 #  created_at  :datetime         not null
 #  updated_at  :datetime         not null
-#  card_id     :string(255)
-#  customer_id :string(255)
-#  user_id     :integer
+#  card_id     :string(255)      not null
+#  customer_id :string(255)      not null
+#  user_id     :integer          not null
+#
+# Indexes
+#
+#  index_cards_on_user_id  (user_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (user_id => users.id)
 #
 FactoryBot.define do
   factory :card do

--- a/spec/models/card_spec.rb
+++ b/spec/models/card_spec.rb
@@ -5,9 +5,17 @@
 #  id          :integer          not null, primary key
 #  created_at  :datetime         not null
 #  updated_at  :datetime         not null
-#  card_id     :string(255)
-#  customer_id :string(255)
-#  user_id     :integer
+#  card_id     :string(255)      not null
+#  customer_id :string(255)      not null
+#  user_id     :integer          not null
+#
+# Indexes
+#
+#  index_cards_on_user_id  (user_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (user_id => users.id)
 #
 require 'rails_helper'
 


### PR DESCRIPTION
# What
自己結合用のアソシエーションを必須から任意(optional: true)に変更
その他微修正

# Why
親要素が必須になっていると最上位のカテゴリを作成する際にエラーとなるため