### PR TITLE
newアクション内のredirect先修正

### DIFF
--- a/app/controllers/card_controller.rb
+++ b/app/controllers/card_controller.rb
@@ -3,7 +3,7 @@ class CardController < ApplicationController
   def new
     @categories = Category.eager_load(children: :children).where(ancestry: nil)
     card = Card.where(user_id: current_user.id)
-    redirect_to action: card_path(card) if card.exists?
+    redirect_to card_path(card) if card.exists?
   end
 
   def pay #payjpとCardのデータベース作成を実施


### PR DESCRIPTION
# What
newアクション内のredirect先の指定を修正した

# Why
誤った記述により、クレジットカード新規登録時、再度新規登録ページに遷移してしまうため