### PR TITLE
ユーザー登録時に空の電話番号を複数登録できない問題の修正

### DIFF
--- a/app/models/shipping_address.rb
+++ b/app/models/shipping_address.rb
@@ -19,8 +19,7 @@
 #
 # Indexes
 #
-#  index_shipping_addresses_on_phone_number  (phone_number) UNIQUE
-#  index_shipping_addresses_on_user_id       (user_id)
+#  index_shipping_addresses_on_user_id  (user_id)
 #
 class ShippingAddress < ApplicationRecord
   belongs_to :user, optional: true

--- a/config/initializers/devise.rb
+++ b/config/initializers/devise.rb
@@ -167,7 +167,7 @@ Devise.setup do |config|
 
   # ==> Configuration for :validatable
   # Range for password length.
-  config.password_length = 6..128
+  config.password_length = 7..128
 
   # Email regex used to validate email formats. It simply asserts that
   # one (and only one) @ exists in the given string. This is mainly

--- a/db/migrate/20200425200330_remove_index_from_shipping_address.rb
+++ b/db/migrate/20200425200330_remove_index_from_shipping_address.rb
@@ -1,0 +1,5 @@
+class RemoveIndexFromShippingAddress < ActiveRecord::Migration[5.0]
+  def change
+    remove_index :shipping_addresses, :phone_number
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20200418033847) do
+ActiveRecord::Schema.define(version: 20200425200330) do
 
   create_table "cards", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
     t.integer  "user_id",     null: false
@@ -105,7 +105,6 @@ ActiveRecord::Schema.define(version: 20200418033847) do
     t.integer  "user_id",                  null: false
     t.datetime "created_at",               null: false
     t.datetime "updated_at",               null: false
-    t.index ["phone_number"], name: "index_shipping_addresses_on_phone_number", unique: true, using: :btree
     t.index ["user_id"], name: "index_shipping_addresses_on_user_id", using: :btree
   end
 

--- a/spec/factories/shipping_addresses.rb
+++ b/spec/factories/shipping_addresses.rb
@@ -19,8 +19,7 @@
 #
 # Indexes
 #
-#  index_shipping_addresses_on_phone_number  (phone_number) UNIQUE
-#  index_shipping_addresses_on_user_id       (user_id)
+#  index_shipping_addresses_on_user_id  (user_id)
 #
 FactoryBot.define do
   factory :shipping_address do

--- a/spec/models/shipping_address_spec.rb
+++ b/spec/models/shipping_address_spec.rb
@@ -19,8 +19,7 @@
 #
 # Indexes
 #
-#  index_shipping_addresses_on_phone_number  (phone_number) UNIQUE
-#  index_shipping_addresses_on_user_id       (user_id)
+#  index_shipping_addresses_on_user_id  (user_id)
 #
 require 'rails_helper'
 
@@ -197,6 +196,12 @@ RSpec.describe ShippingAddress do
         address = build(:shipping_address)
         address.valid?
         expect(address.errors[:phone_number]).to include('はすでに存在します')
+      end
+
+      it 'すでに電話番号が未入力のデータがある場合も登録できる' do
+        build(:shipping_address, phone_number: '').save
+        address = build(:shipping_address, phone_number: '', user_id: '2')
+        expect(address).to be_valid
       end
     end
 


### PR DESCRIPTION
# What
shipping_addressesテーブルのphone_numberカラムに設定されているunique制約を解除。

# Why
unique制約が設定されていると電話番号の値が空白のデータを複数のユーザーレコードで持つことができないため。