### PR TITLE
カードのブランドロゴ表示追加

### DIFF
--- a/app/assets/stylesheets/card/show.scss
+++ b/app/assets/stylesheets/card/show.scss
@@ -20,11 +20,12 @@ $mainWhite: #fff;
   &__info {
     padding-left: 170px;
     &--title {
-      padding: 70px 0 15px 0;
+      padding: 50px 0 25px 0;
       font-weight: bold;
     }
     &--number {
       font-size: 14px;
+      padding-top: 5px;
     }
   }
   

--- a/app/controllers/card_controller.rb
+++ b/app/controllers/card_controller.rb
@@ -44,8 +44,22 @@ class CardController < ApplicationController
       Payjp.api_key = ENV["PAYJP_PRIVATE_KEY"]
       customer = Payjp::Customer.retrieve(card.customer_id)
       @default_card_information = customer.cards.retrieve(card.card_id)
+      @card_brand = @default_card_information.brand 
+      case @card_brand
+      when "Visa"
+        @card_src = "card_logo_visa.png"
+      when "MasterCard"
+        @card_src = "card_logo_master.png"
+      when "Saison"
+        @card_src = "card_logo_saisonr.png"
+      when "JCB"
+        @card_src = "card_logo_jcb.gif"
+      when "American Express"
+        @card_src = "card_logo_amex.gif"
+      end
     else
       redirect_to new_card_path
     end
   end
+
 end

--- a/app/views/card/show.html.haml
+++ b/app/views/card/show.html.haml
@@ -8,8 +8,9 @@
   .card__confirmation__container__info
     .card__confirmation__container__info--title
       クレジットカード情報
+    .card__confirmation__container__info--brand
+      = image_tag "#{@card_src}",alt: @card_brand, size: "38x28", id: "card_image"  
     .card__confirmation__container__info--number
-      %br
       = "**** **** **** " + @default_card_information.last4
       %br
       - exp_month = @default_card_information.exp_month.to_s


### PR DESCRIPTION
# What
登録済みクレジットカードの情報表示の際、
カードのブランドロゴ(VISA、JCB等)も表示されるようコードを追加した。

# Why
一般的に表示がされていることと、
ロゴがあることでより視覚的にカード情報であると認識しやすくなる為。

<img width="683" alt="b1bc728a99c7ba3629ad820b9bce94c5" src="https://user-images.githubusercontent.com/61226318/80629063-44f2b500-8a8d-11ea-8023-42bf96107c6f.png">
