### PR TITLE
商品の状態に関する実装の修正

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,7 +78,6 @@
 - belongs_to :size
 - belongs_to_active_hash :ship_from_location
 - belongs_to_active_hash :product_condition
-- belongs_to_active_hash :product_status
 - belongs_to_active_hash :derivery_fee_payer
 - belongs_to_active_hash :derivery_day
 - belongs_to_active_hash :derivery_method

--- a/app/models/product.rb
+++ b/app/models/product.rb
@@ -46,7 +46,6 @@ class Product < ApplicationRecord
   belongs_to_active_hash :derivery_fee_payer
   belongs_to_active_hash :derivery_day
   belongs_to_active_hash :derivery_method
-  belongs_to_active_hash :product_status
 
   validates :product_images, presence: true, length: {manimum: 1, maximum: 10}
   validates :name, presence: true, length: { maximum: 40 }

--- a/app/models/product_status.rb
+++ b/app/models/product_status.rb
@@ -1,5 +1,0 @@
-class ProductStatus < ActiveHash::Base
-  self.data = [
-    {id: 1, status: '出品中'},{id: 2, status: '売却済'}
-  ]
-end

--- a/app/views/products/new.html.haml
+++ b/app/views/products/new.html.haml
@@ -100,6 +100,5 @@
                     = session[:price_error]
           #product-price__wrapper--bottom
             =f.submit '出品する', class:"send-btn"
-            =f.hidden_field :product_status_id, :value => 1
             = link_to '/products', class:"return-top", method: :get do
               もどる


### PR DESCRIPTION
# why
実装の変更に伴い、修正が必要である為。

# what
-product_statusのアソシエーションを消去
- active-hashでproductモデルと紐付けたproduct_statusモデルの消去
- 商品出品フォームでproduct_statusの値を送る処理の消去。
- README内でproduct_statusに関する記述を消去