### PR TITLE
【マークアップ】商品購入確認ページ

### DIFF
--- a/app/assets/stylesheets/_products.scss
+++ b/app/assets/stylesheets/_products.scss
@@ -489,23 +489,21 @@ a {
             width: 100%;
             z-index: auto;
             object-fit: cover;
-
-            // 以下、商品購入機能のマークアップ実装時に使用予定です 
-            // &-sold {
-            //   border-width: 110px 110px 0 0;
-            //   border-color: #3CCACE transparent transparent transparent;
-            //   position: absolute;
-            //   border-style: solid;
-            //   &__inner {
-            //     top: -90px;
-            //     font-size: 23px;
-            //     position: absolute;
-            //     color: #fff;
-            //     transform: rotate(-45deg);
-            //     letter-spacing: 3px;
-            //     font-weight: bold;
-            //   }
-            // }
+            &-sold {
+              border-width: 110px 110px 0 0;
+              border-color: #3CCACE transparent transparent transparent;
+              position: absolute;
+              border-style: solid;
+              &__inner {
+                top: -90px;
+                font-size: 23px;
+                position: absolute;
+                color: #fff;
+                transform: rotate(-45deg);
+                letter-spacing: 3px;
+                font-weight: bold;
+              }
+            }
           }
         }
          

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -12,3 +12,5 @@
 @import "search";
 @import "product/new";
 @import "product/exhibition_complete";
+@import "purchase/show";
+@import "purchase/done";

--- a/app/assets/stylesheets/purchase/_done.scss
+++ b/app/assets/stylesheets/purchase/_done.scss
@@ -1,0 +1,55 @@
+*{
+  box-sizing: border-box;
+}
+
+$mainWhite: #fff;
+
+.purchase__done {
+  width: 100%;
+  min-height: 100vh;
+  background-color: #f1f1f1;
+
+  &__header {
+    height: 100px;
+    width: 100vw;
+    line-height: 160px;
+    text-align: center;
+  }
+
+  &__container {
+    width: 700px;
+    background-color: $mainWhite;
+    margin: 32px auto ;
+    color: #333;
+    text-align: center;
+    &--head {
+      padding: 40px;
+    }
+    &--product__box {
+      height: 120px;
+      display: flex;
+      justify-content: center;
+      &--info {
+        padding-left: 20px;
+        font-size: 15px;
+        text-align: left;
+        &__name {
+          padding-bottom: 10px;
+        }  
+      }
+    }
+    .back__to__top {
+      background-color: #3CCACE;
+      line-height: 60px;
+      font-size: 18px;
+      :hover {
+        background-color:  rgb(37, 176, 180);
+      }
+      &--btn {
+        display: block;
+        text-decoration: none;
+        color: $mainWhite;
+      }
+    }
+  }
+}

--- a/app/assets/stylesheets/purchase/_show.scss
+++ b/app/assets/stylesheets/purchase/_show.scss
@@ -1,0 +1,162 @@
+*{
+  box-sizing: border-box;
+}
+
+$mainWhite: #fff;
+$mainBlack: #333;
+
+@mixin borderTop {
+  border-top: 1px solid #f5f5f5;
+}
+
+@mixin betweenItemsPadding {
+  padding: 35px 170px 5px;
+}
+
+@mixin spaceBetween {
+  display: flex;
+  justify-content: space-between;
+}
+
+@mixin cardEdit {
+  color: #0099e8;
+  text-decoration: none;
+}
+
+.buy__product {
+  width: 100%;
+  min-height: 100vh;
+  background-color: #f1f1f1;
+  &__header {
+    height: 128px;
+    width: 100vw;
+    line-height: 160px;
+    text-align: center;
+  }
+
+  &__container {
+    height: calc(100vh-128px);
+    width: 700px;
+    background-color: $mainWhite;
+    color: $mainBlack;
+    margin: 0 auto;
+    &--head {
+      padding: 32px;
+      font-size: 22px;
+      font-weight: 600;
+      text-align: center;
+    }
+
+    &--product__box {
+      height: 120px;
+      padding: 35px 16px;
+      display: flex;
+      justify-content: center;
+      color: $mainBlack;
+      @include borderTop;
+      &--info {
+        padding-left: 20px;
+        font-size: 15px;
+        text-align: left;
+        &__name {
+          padding-bottom: 10px;
+        }  
+      }
+    }
+
+    &--user__info {
+      &__inner{
+        @include borderTop;
+        &--price {
+          @include betweenItemsPadding;
+          @include spaceBetween;
+          font-weight: bold;
+          &__title {
+            font-size: 18px;
+          }
+          &__amount {
+            font-size: 22px;
+          }
+        }
+        &--payment {
+          @include borderTop;
+          @include betweenItemsPadding;
+          &__head {
+            @include spaceBetween;
+            font-size: 18px;
+            padding-bottom: 5px;
+            &--title {
+              font-weight: bold;
+              font-size: 15px;
+            }
+            &--edit {
+              font-size: 15px;
+              .card_registration {
+                @include cardEdit;
+              }
+            }
+          }
+          &__card {
+            font-size: 13px;
+            h3 {
+              font-size: 15px;
+              padding-bottom: 5px;
+            }
+            .card__register {
+              color: #0099e8;
+              font-size: 15px;
+            }
+            .card_registration {
+              @include cardEdit;
+            }
+          }
+        }
+
+        &--shipping__address {
+          @include borderTop;
+          @include betweenItemsPadding;
+          font-size: 13px;
+          h3 {
+            padding-bottom: 5px;
+            font-weight: bold;
+            font-size: 15px;
+          }
+        }
+
+        &--purchase__btn {
+          @include borderTop;
+          padding: 35px 170px;
+          display: block;
+          .available {
+            width: 100%;
+            background-color: #3CCACE;
+            color: $mainWhite;
+            line-height: 48px;
+            font-size: 14px;
+            outline: 0;
+            display: block;
+          }
+          .unavailable {
+            width: 100%;
+            background-color: #888;
+            color: $mainWhite;
+            line-height: 48px;
+            font-size: 14px;
+            pointer-events: none;
+          }
+        }
+      }
+    }
+  }
+
+  &__footer {
+    height: 128px;
+    text-align: center;
+    font-size: 12px;
+    &__lists {
+      padding: 16px 520px;
+      @include betweenItemsPadding;
+    }
+  }
+  
+}

--- a/app/views/purchase/done.html.haml
+++ b/app/views/purchase/done.html.haml
@@ -1,19 +1,20 @@
--# = render "products/header"
--# = render 'users/mypage_side_nav'
+.purchase__done
+  .purchase__done__header
+    = link_to image_tag("logo.png", size: "185x50", class: "buy__product__header--image"), root_path
 
-.purchase__done__container
-  .purchase__done__container--head
-  %h2 購入が完了しました
+  .purchase__done__container
+    .purchase__done__container--head
+      %h2 購入が完了しました！
 
-  .purchase__done__container--product__box
-    .purchase__done__container--product__box--image
-      = image_tag(@product.product_images.first.url, size: "80x80", class: "product__image")
-    .purchase__done__container--product__box--name
-      = @product.name
-    .purchase__done__container--product__box--price
-      = number_to_currency(@product.price, format: "%u%n", unit: "¥", precision: 0)
+    .purchase__done__container--product__box
+      .purchase__done__container--product__box--image
+        = image_tag(@product.product_images.first.url, size: "90x70", class: "product__image")
+      .purchase__done__container--product__box--info
+        .purchase__done__container--product__box--info__name
+          = @product.name
+        .purchase__done__container--product__box--info__price
+          = number_to_currency(@product.price, format: "%u%n", unit: "¥", precision: 0)
 
-.back__to__top
-  = link_to "トップページへもどる", root_path
-
--# = render 'products/footer'
+    .back__to__top
+      = link_to "/products", class: "back__to__top--btn", method: :get do
+        トップページへ戻る

--- a/app/views/purchase/show.html.haml
+++ b/app/views/purchase/show.html.haml
@@ -1,6 +1,6 @@
 .buy__product
   .buy__product__header
-    = link_to image_tag("logo.png", size: "180x50", class: "buy__product__header--image"), root_path
+    = link_to image_tag("logo.png", size: "185x50", class: "buy__product__header--image"), root_path
 
   .buy__product__container
     .buy__product__container--head
@@ -8,75 +8,83 @@
 
     .buy__product__container--product__box
       .buy__product__container--product__box--image
-      = image_tag(@product.product_images.first.url, size: "80x80", class: "product__image")
+        = image_tag(@product.product_images.first.url, size: "90x70", class: "product__image")
       .buy__product__container--product__box--info
-        %p.product__name
+        .buy__product__container--product__box--info__name
           = @product.name
-          %p.product__price.bold
-            = number_to_currency(@product.price, format: "%u%n", unit: "¥", precision: 0)
-            %span.product__shipping__fee.f14.bold
-              = @product.derivery_fee_payer.derivery_fee_payer
+        .buy__product__container--product__box--info__price
+          = number_to_currency(@product.price, format: "%u%n", unit: "¥", precision: 0)
+          %span.product__shipping__fee.f14.bold
+            = @product.derivery_fee_payer.derivery_fee_payer
 
     %br
     .buy__product__container--user__info
       .buy__product__container--user__info__inner
-        %ul.buy__product__container--user__info__inner--price
-          %li.price__title.bold
-          支払い金額
-          %li.price__amount
+        .buy__product__container--user__info__inner--price
+          .buy__product__container--user__info__inner--price__title
+            支払い金額
+          .buy__product__container--user__info__inner--price__amount
             = number_to_currency(@product.price, format: "%u%n", unit: "¥", precision: 0)
 
-      %br
-      .buy__product__container--user__info__inner--payment
-        %h3 支払方法
-        クレジットカード
-        - if @default_card_information.present?
-          .payment__card
-            .payment__card__number
-              = "**** **** **** " + @default_card_information.last4
-            .payment__card__expiration
-              - exp_month = @default_card_information.exp_month.to_s
-              - exp_year = @default_card_information.exp_year.to_s.slice(2,3)
-              = "有効期限 #{exp_month + " / " + exp_year}"
-            %figure
-              = image_tag "#{@card_src}", alt: @card_brand, size: "35x25", id: "card_image"
-            .payment__card__edit
-            = icon('fas', 'sync-alt')
-            = link_to "カードを変更する", card_path, class: "card_registration"
-        - else
-          .payment__card__register
-            = icon('fas', 'plus-circle')
-            = link_to "登録してください", new_card_path, class: "card_registration"
-
-      %br
-      .buy__product__container--user__info__inner--shipping__address
-        %h3 配送先
-        .user__address
-          = "〒 #{current_user.shipping_address.post_code.to_s.insert(3,"-")}"
-          %br
-          = current_user.shipping_address.prefecture
-          = current_user.shipping_address.city
-          = current_user.shipping_address.address_number
-          = current_user.shipping_address.building_name
-          %br
-          = current_user.shipping_address.address_family_name
-          = current_user.shipping_address.address_first_name
         %br
+        .buy__product__container--user__info__inner--payment
+          .buy__product__container--user__info__inner--payment__head
+            .buy__product__container--user__info__inner--payment__head--title
+              支払い方法
+            .buy__product__container--user__info__inner--payment__head--edit
+              - if @default_card_information.present?
+                .card__edit
+                  = link_to "変更する", card_path, class: "card_registration"
+          
+          .buy__product__container--user__info__inner--payment__card
+            - if @default_card_information.present?
+              .payment__card
+                .payment__card__number
+                  %h3 クレジットカード
+                  = "**** **** **** " + @default_card_information.last4
+                .payment__card__expiration
+                  - exp_month = @default_card_information.exp_month.to_s
+                  - exp_year = @default_card_information.exp_year.to_s.slice(2,3)
+                  = "有効期限 #{exp_month + " / " + exp_year}"
+                  %br
+                  = image_tag "#{@card_src}", alt: @card_brand, size: "35x25", id: "card_image"
+            - else
+              .card__register
+                = icon('fas', 'plus-circle')
+                = link_to "登録してください", new_card_path, class: "card_registration"
 
-      - if @default_card_information.present?
-        = form_tag(pay_purchase_path(@product), action: :pay, method: :post) do
-          %button.button1 購入する
-      - else
         %br
+        .buy__product__container--user__info__inner--shipping__address
+          %h3 配送先
+          .user__address
+            = "〒 #{current_user.shipping_address.post_code.to_s.insert(3,"-")}"
+            %br
+            = current_user.shipping_address.prefecture
+            = current_user.shipping_address.city
+            = current_user.shipping_address.address_number
+            = current_user.shipping_address.building_name
+            %br
+            = current_user.shipping_address.address_family_name
+            = current_user.shipping_address.address_first_name
+          %br
 
-%br
-.exhibit__page__footer
-  %ul.exhibit-page__footer__lists
-    %li.exhibit-page__footer__lists--1
-      プライバシーポリシー
-    %li.exhibit-page__footer__lists--2
-      FURIMA利用規約
-    %li.exhibit-page__footer__lists--3
-      特定商取引に関する表記
-    %p.exhibit-page__footer__lists--copyright
+        .buy__product__container--user__info__inner--purchase__btn
+          - if @default_card_information.present?
+            = form_tag(pay_purchase_path(@product), action: :pay, method: :post) do
+              %button.available 購入する
+          - else
+            = form_tag(pay_purchase_path(@product), action: :pay, method: :post) do
+              %button.unavailable 購入する
+
+  %br
+  .buy__product__footer
+    .buy__product__footer__lists
+      .buy__product__footer__lists--1
+        プライバシーポリシー
+      .buy__product__footer__lists--2
+        FURIMA利用規約
+      .buy__product__footer__lists--3
+        特定商取引に関する表記
+
+    .buy__product__footer__lists--copyright
       © FURIMA,Inc.


### PR DESCRIPTION
# What
購入確定前の商品購入確認ページ、及び購入完了ページのマークアップ

# Why
必須機能であり、また購入内容をより簡単に確認できるようにする為。

＜購入内容確認ページ＞
---------------------------------------
①クレジットカード情報を既に登録済の場合
<img width="1440" alt="購入内容確認ページ（カード登録あり）" src="https://user-images.githubusercontent.com/61226318/81913395-e25ff400-960a-11ea-875b-81ebf44adad6.png">


②クレジットカード未登録の場合
<img width="1440" alt="購入内容確認ページ（カード登録なし）" src="https://user-images.githubusercontent.com/61226318/81913537-15a28300-960b-11ea-94db-b1c4f983d21b.png">


＜商品購入完了ページ＞
---------------------------------------
<img width="1439" alt="商品購入完了ページ" src="https://user-images.githubusercontent.com/61226318/81910937-8e074500-9607-11ea-838a-4b69df79d4f7.png">

＜トップページの商品一覧にある購入済み商品＞
---------------------------------------
※商品購入に関わる追加実装
![商品一覧ページの購入済商品の表示](https://user-images.githubusercontent.com/61226318/81911243-0241e880-9608-11ea-9789-08da2d6f8a01.jpg)
