### PR TITLE
商品詳細 /「売り切れました」ボタンの装飾追加

### DIFF
--- a/app/assets/stylesheets/product/_show.scss
+++ b/app/assets/stylesheets/product/_show.scss
@@ -121,6 +121,15 @@ ul.bottom_button{
           border: 1px solid #3CCACE;
           color: #fff;
         }
+        .disabled-button {
+          font-size: 18px;
+          background-color: #888;
+          padding: 15px 100px;
+          border-radius: 100px;
+          border: 1px solid #888;
+          color: #fff;
+          pointer-events: none;
+        }
         &--promote_page{
           font-size: 18px;
           background-color: #3CCACE;

--- a/app/views/products/show.html.haml
+++ b/app/views/products/show.html.haml
@@ -90,9 +90,9 @@
               %li 
                 = link_to "商品の削除", "#", class: "top_content__product_box__buy_button--destroy_button"
           - elsif @product.status == "購入済み"
-            = link_to "売り切れました", "#" ,class:"disabled-button bold"
+            = link_to "売り切れました", "#" ,class:"disabled-button"
           - else
-            = link_to "購入画面へ進む", "purchase_path", class: "top_content__product_box__buy_button--promote_page"
+            = link_to "購入画面へ進む", purchase_path, class: "top_content__product_box__buy_button--promote_page"
         - else 
           %p
       .top_content__product_box__bottom


### PR DESCRIPTION
# What
・購入済みの商品詳細ページ、「売り切れました」ボタンを装飾
・scssをあてる為、「売り切れました」ボタンのclass名を一部変更

# Why
実装いただいた商品詳細ページのビューにデザインを合わせる為。

＜購入済み商品の詳細ページ＞
--------------------------------------------------
<img width="1440" alt="商品詳細:売り切れボタン装飾" src="https://user-images.githubusercontent.com/61226318/81945592-44cfe900-9639-11ea-8f41-c32235106e34.png">
