### PR TITLE
購入した商品一覧ページの実装

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@
 - belongs_to_active_hash :derivery_method
 - belongs_to :category
 - has_one :order, dependent: :destroy
-- has_one :buyer_user, through: :orders
+- has_one :user, through: :orders
 
 ## product_imagesテーブル
 |Column|Type|Options|
@@ -136,8 +136,8 @@
 ## ordersテーブル
 |Column|Type|Options|
 |------|----|-------|
-|buyer_user_id|references|null: false, foreign_key: true|
+|user_id|references|null: false, foreign_key: true|
 |product_id|references|null: false, foreign_key: true|
 ### Association
-- belongs_to: user
-- belongs_to: product
+- belongs_to :user
+- belongs_to :product

--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -16,3 +16,4 @@
 @import "purchase/show";
 @import "purchase/done";
 @import "mypage/selling";
+@import "mypage/purchasing";

--- a/app/assets/stylesheets/mypage/_purchasing.scss
+++ b/app/assets/stylesheets/mypage/_purchasing.scss
@@ -1,0 +1,130 @@
+*{
+  box-sizing: border-box;
+}
+
+$mainWhite: #fff;
+$mainGray: #ccc;
+$mainLightGray: #eee;
+$mainBlack: #333;
+
+@mixin productStatus {
+  display: inline-block;
+  margin: 0 0 0 7px;
+  padding: 2px 7px;
+  border-radius: 3px;
+  color: $mainWhite;
+  font-size: 12px;
+  font-weight: bold;
+}
+
+@mixin tabsDesign {
+  background-color: $mainWhite;
+  border: solid 2px;
+  border-color: #3CCACE $mainWhite $mainWhite $mainWhite
+}
+
+@mixin tabsShape {
+  height: 70px;
+  width: calc(700px/2);
+  background-color: $mainLightGray;
+  float: left;
+  line-height: 60px;
+  text-align: center;
+  font-weight: bold;
+  &:hover {
+    opacity: 0.7;
+  }
+}
+
+@mixin between {
+  display: flex;
+  justify-content: space-between;
+}
+
+.purchasing__products {
+  min-height: 100vh;
+  width: 700px;
+  position: absolute;
+  top: 100px;
+  margin: 50px 0 0 520px;
+  &__title {
+    background-color: #f0ffff;
+    padding: 0 16px;
+    font-size: 16px;
+    line-height: 72px
+  }
+
+  &__tabs {
+    background-color: $mainWhite;
+
+    input[name="tabs2"] {
+      display: none;
+    }
+
+    input[name="tabs2"]:checked + .tab_exhibition {
+      @include tabsDesign; 
+    }
+
+    .tab_exhibition {
+      @include tabsShape;
+    }
+
+    #now_dealing:checked ~ .content1, #past_transaction:checked ~ .content2 {
+      display: block;
+    }
+  }
+
+  .tab__content {
+    display: none;
+    clear: both;
+    overflow: hidden;
+    list-style: none;
+  
+    &__list {
+      &__products {
+        border-bottom: solid 0.1px $mainLightGray;
+        display: flex;
+        &--image {
+          padding: 15px;
+        }
+        &--text {
+          font-size: 14px;
+          padding-top: 15px;
+          &__name {
+            padding: 0 0 10px 10px;
+            color: $mainBlack;
+          }
+          &__btn {
+            display: flex;
+            color: #808080;
+            &--favorite__btn {
+              padding-right: 8px;
+            }
+            &--comment__btn {
+              padding-right: 8px;
+            }
+            &--status {
+              &__dealing {
+                @include productStatus;
+                background-color: #3CCACE;
+              }
+              &__completed {
+                @include productStatus;
+                background-color: #888;
+              }
+            }
+          }
+        }
+      }
+    }
+    &__noproducts {
+      height: 300px;
+      background-color: $mainWhite;
+      padding-top: 100px;
+      color: $mainGray;
+      text-align: center;
+      font-size: 16px;
+      font-weight: bold;
+    }
+  }
+}

--- a/app/assets/stylesheets/mypage/_selling.scss
+++ b/app/assets/stylesheets/mypage/_selling.scss
@@ -10,8 +10,8 @@ $mainBlack: #333;
 @mixin productStatus {
   display: inline-block;
   margin: 0 0 0 7px;
-  padding: 2px 4px;
-  border-radius: 5px;
+  padding: 2px 7px;
+  border-radius: 3px;
   color: $mainWhite;
   font-size: 12px;
   font-weight: bold;
@@ -91,7 +91,7 @@ $mainBlack: #333;
           font-size: 14px;
           padding-top: 15px;
           &__name {
-            padding-bottom: 10px;
+            padding: 0 0 10px 10px;
             color: $mainBlack;
           }
           &__btn {

--- a/app/controllers/purchase_controller.rb
+++ b/app/controllers/purchase_controller.rb
@@ -40,7 +40,7 @@ class PurchaseController < ApplicationController
       currency: 'jpy', 
     )
     
-    if @product.update(status: "購入済み" ) && Order.create!(buyer_user_id: current_user.id, product_id: @product.id)
+    if @product.update(status: "購入済み" ) && Order.create!(user_id: current_user.id, product_id: @product.id)
       redirect_to done_purchase_path #購入完了画面へ遷移
     end
 

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,22 +1,32 @@
 class UsersController < ApplicationController
+  before_action :set_categories, only: [:show, :logout, :selling, :purchasing]
   
   def show
     user = User.find(params[:id])
     @nickname = user.nickname
-    @categories = Category.eager_load(children: :children).where(ancestry: nil)
   end
 
   def logout
-    @categories = Category.eager_load(children: :children).where(ancestry: nil)
   end
 
   def selling
     @products = Product.where(user_id: params[:id])
     @products_by_status = @products.group(:status).count
     @selling_products = @products.where(status:'出品中').order("created_at DESC").page(params[:page]).per(10)
-    @dealing_products = @products.where(status:'取引中').order("created_at DESC").page(params[:page]).per(10)
+    @dealing_products = @products.where(status:'取引中').order("created_at DESC").page(params[:page]).per(10) 
     @sold_products = @products.where(status:'購入済み').order("created_at DESC").page(params[:page]).per(10)
-    @categories = Category.eager_load(children: :children).where(ancestry: nil)
+  end
+
+  def purchasing
+    @products = Product.where(user_id: params[:id])
+    @products_by_status = @products.group(:status).count
+    @dealing_products = @products.where(status:'取引中').order("created_at DESC").page(params[:page]).per(10)
+    @orders = Order.where(user_id: current_user.id).order("created_at DESC").page(params[:page]).per(10)
   end
   
+  private
+  def set_categories
+    @categories = Category.eager_load(children: :children).where(ancestry: nil)
+  end
+
 end

--- a/app/models/order.rb
+++ b/app/models/order.rb
@@ -2,23 +2,23 @@
 #
 # Table name: orders
 #
-#  id            :integer          not null, primary key
-#  created_at    :datetime         not null
-#  updated_at    :datetime         not null
-#  buyer_user_id :integer          not null
-#  product_id    :integer          not null
+#  id         :integer          not null, primary key
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  product_id :integer          not null
+#  user_id    :integer          not null
 #
 # Indexes
 #
-#  index_orders_on_buyer_user_id  (buyer_user_id)
-#  index_orders_on_product_id     (product_id)
+#  index_orders_on_product_id  (product_id)
+#  index_orders_on_user_id     (user_id)
 #
 # Foreign Keys
 #
-#  fk_rails_...  (buyer_user_id => users.id)
 #  fk_rails_...  (product_id => products.id)
+#  fk_rails_...  (user_id => users.id)
 #
 class Order < ApplicationRecord
-  belongs_to :buyer_user, class_name: "User", foreign_key: "buyer_user_id"
+  belongs_to :user, class_name: "User", foreign_key: "user_id"
   belongs_to :product
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -23,7 +23,7 @@ class User < ApplicationRecord
   has_one :profile,          dependent: :destroy
   has_one :shipping_address, dependent: :destroy
   has_many :comments
-  has_many :orders, class_name: "Order", foreign_key: "buyer_user_id"
+  has_many :orders, class_name: "Order", foreign_key: "user_id"
   has_many :products, through: :ordres
   validates :nickname,
             presence: true,

--- a/app/views/users/_mypage_side_nav.html.haml
+++ b/app/views/users/_mypage_side_nav.html.haml
@@ -21,7 +21,7 @@
       = link_to selling_user_path(current_user.id), class: 'left__content__list-item' do
         出品した商品一覧
       %li
-      = link_to '#', class: 'left__content__list-item' do
+      = link_to purchasing_user_path(current_user.id), class: 'left__content__list-item' do
         購入した商品一覧
       %li
       = link_to '#', class: 'left__content__list-item' do

--- a/app/views/users/purchasing.html.haml
+++ b/app/views/users/purchasing.html.haml
@@ -1,0 +1,74 @@
+= render 'products/header'
+= render 'mypage_side_nav'
+
+.purchasing__products
+  .purchasing__products__title 
+    購入した商品
+
+  .purchasing__products__tabs
+    %input#now_dealing{checked: "checked", name: "tabs2", type: "radio"}
+    %label.tab_exhibition{for: "now_dealing"} 
+      取引中
+
+    %input#past_transaction{name: "tabs2", type: "radio"}
+    %label.tab_exhibition{for: "past_transaction"} 
+      過去の取引
+
+
+    #now_dealing.tab__content.content1
+      - if @dealing_products.present?
+        - @dealing_products.each do |product|
+          %li
+          .tab__content__list
+            = link_to product_path(product.id), class: "product__list__detail", method: :get do
+              .tab__content__list__products
+                .tab__content__list__products--image
+                  = image_tag product.product_images.first.url, size: "60x50", class: "product__image"
+
+                .tab__content__list__products--text
+                  .tab__content__list__products--text__name
+                    = product.name
+
+                  .tab__content__list__products--text__btn
+                    .tab__content__list__products--text__btn--favorite__btn
+                      = icon('fa', 'star')
+                      0
+                    .tab__content__list__products--text__btn--comment__btn
+                      = icon('fas', 'comment')
+                      0
+                    .tab__content__list__products--text__btn--status__dealing
+                      取引中
+
+        = paginate @dealing_products
+
+      - else
+        .tab__content__noproducts
+          = image_tag "logo_gray.jpg", size: "70x70", class: "logo_gray_image"  
+          %p.c-txtsp 取引中の商品はありません
+
+    #past_transaction.tab__content.content2
+      - if @orders.present?
+        - @orders.each do |order|
+          %li
+          .tab__content__list
+            = link_to product_path(order.product.id), class: "product__list__detail", method: :get do
+              .tab__content__list__products
+                .tab__content__list__products--image
+                  = image_tag order.product.product_images.first.url, size: "60x50", class: "product__image"
+
+                .tab__content__list__products--text
+                  .tab__content__list__products--text__name
+                    = order.product.name
+
+                  .tab__content__list__products--text__btn
+                    .tab__content__list__products--text__btn--status__completed
+                      取引完了
+
+        = paginate @orders
+
+      - else
+        .tab__content__noproducts
+          = image_tag "logo_gray.jpg", size: "70x70", class: "logo_gray_image"  
+          %p.c-txtsp 過去に取引した商品はありません
+
+= render 'products/footer'

--- a/app/views/users/selling.html.haml
+++ b/app/views/users/selling.html.haml
@@ -97,12 +97,6 @@
                     = product.name
 
                   .tab__content__list__products--text__btn
-                    .tab__content__list__products--text__btn--favorite__btn
-                      = icon('fa', 'star')
-                      0
-                    .tab__content__list__products--text__btn--comment__btn
-                      = icon('fas', 'comment')
-                      0
                     .tab__content__list__products--text__btn--status__sold
                       売却済
 

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -33,6 +33,7 @@ Rails.application.routes.draw do
       get 'card',    to: 'card#show'
       get 'logout',  to: 'users#logout'
       get 'selling', to: 'users#selling'
+      get 'purchasing'
     end
   end
 

--- a/db/migrate/20200405084411_create_orders.rb
+++ b/db/migrate/20200405084411_create_orders.rb
@@ -1,11 +1,11 @@
 class CreateOrders < ActiveRecord::Migration[5.0]
   def change
     create_table :orders do |t|
-      t.references :buyer_user, null: false
+      t.references :user, null: false
       t.references :product, null: false
       t.timestamps
     end
-    add_foreign_key :orders, :users, column: "buyer_user_id"
+    add_foreign_key :orders, :users, column: "user_id"
     add_foreign_key :orders, :products
   end
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -39,12 +39,12 @@ ActiveRecord::Schema.define(version: 20200502080755) do
   end
 
   create_table "orders", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
-    t.integer  "buyer_user_id", null: false
-    t.integer  "product_id",    null: false
-    t.datetime "created_at",    null: false
-    t.datetime "updated_at",    null: false
-    t.index ["buyer_user_id"], name: "index_orders_on_buyer_user_id", using: :btree
+    t.integer  "user_id",    null: false
+    t.integer  "product_id", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
     t.index ["product_id"], name: "index_orders_on_product_id", using: :btree
+    t.index ["user_id"], name: "index_orders_on_user_id", using: :btree
   end
 
   create_table "product_images", force: :cascade, options: "ENGINE=InnoDB DEFAULT CHARSET=utf8" do |t|
@@ -134,7 +134,7 @@ ActiveRecord::Schema.define(version: 20200502080755) do
   add_foreign_key "category_sizes", "categories"
   add_foreign_key "category_sizes", "sizes"
   add_foreign_key "orders", "products"
-  add_foreign_key "orders", "users", column: "buyer_user_id"
+  add_foreign_key "orders", "users"
   add_foreign_key "product_images", "products"
   add_foreign_key "products", "categories"
   add_foreign_key "products", "sizes"

--- a/spec/factories/orders.rb
+++ b/spec/factories/orders.rb
@@ -2,21 +2,21 @@
 #
 # Table name: orders
 #
-#  id            :integer          not null, primary key
-#  created_at    :datetime         not null
-#  updated_at    :datetime         not null
-#  buyer_user_id :integer          not null
-#  product_id    :integer          not null
+#  id         :integer          not null, primary key
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  product_id :integer          not null
+#  user_id    :integer          not null
 #
 # Indexes
 #
-#  index_orders_on_buyer_user_id  (buyer_user_id)
-#  index_orders_on_product_id     (product_id)
+#  index_orders_on_product_id  (product_id)
+#  index_orders_on_user_id     (user_id)
 #
 # Foreign Keys
 #
-#  fk_rails_...  (buyer_user_id => users.id)
 #  fk_rails_...  (product_id => products.id)
+#  fk_rails_...  (user_id => users.id)
 #
 FactoryBot.define do
   factory :order do

--- a/spec/models/order_spec.rb
+++ b/spec/models/order_spec.rb
@@ -2,21 +2,21 @@
 #
 # Table name: orders
 #
-#  id            :integer          not null, primary key
-#  created_at    :datetime         not null
-#  updated_at    :datetime         not null
-#  buyer_user_id :integer          not null
-#  product_id    :integer          not null
+#  id         :integer          not null, primary key
+#  created_at :datetime         not null
+#  updated_at :datetime         not null
+#  product_id :integer          not null
+#  user_id    :integer          not null
 #
 # Indexes
 #
-#  index_orders_on_buyer_user_id  (buyer_user_id)
-#  index_orders_on_product_id     (product_id)
+#  index_orders_on_product_id  (product_id)
+#  index_orders_on_user_id     (user_id)
 #
 # Foreign Keys
 #
-#  fk_rails_...  (buyer_user_id => users.id)
 #  fk_rails_...  (product_id => products.id)
+#  fk_rails_...  (user_id => users.id)
 #
 require 'rails_helper'
 


### PR DESCRIPTION
# What
マイページの出品した商品一覧ページ作成に続き、＜購入した商品一覧ページ＞を追加。
（メニューサイドバーの「購入した商品一覧」から遷移）
・購入した商品 -取引中
・購入した商品 -過去の取引（購入済商品）
・出品した商品と同じく、1項目の表示が10商品以上の場合は、ページネーションで次ページへ。
・ordersテーブルのカラム名「buyer_user_id」を「user_id」へ変更
（ordersテーブルは、usersテーブルとproductsテーブルの中間テーブルであり、
過去の取引に関する商品データをorders中間テーブルを介して取得する際、カラム名がテーブル名と一致した外部キー名になっていないとデータが取得できない為。）

# Why
マイページの利便性を向上させる為。

＜取引中の商品一覧＞
---------------------------------------
現時点では、productsのstatus"取引中"は定義していないので、
「取引中の商品はありません」と表示されます。
過去の取引（購入済商品）に関しても、該当の商品がなければ「〜の商品はありません」と同様の表示がされます。
<img width="1440" alt="購入した商品一覧（取引中）" src="https://user-images.githubusercontent.com/61226318/82423996-83452800-9abf-11ea-8f35-7c088c209e2b.png">

＜過去の取引商品一覧＞
---------------------------------------
<img width="1440" alt="購入した商品一覧（過去の取引）" src="https://user-images.githubusercontent.com/61226318/82424017-8d672680-9abf-11ea-8256-c63c5e88cc1a.png">
