### PR TITLE
Seedファイルの入力値の誤りを修正

### DIFF
--- a/db/seeds/category_size.rb
+++ b/db/seeds/category_size.rb
@@ -105,7 +105,7 @@ end
 n = 245
 8.times do 
   CategorySize.create!(
-    category_id: n, size_id: 52
+    category_id: n, size_id: 29
   )
   n += 1
 end


### PR DESCRIPTION
# What
- category_sizesテーブルのSeedファイルを修正

# Why
- 誤ったサイズを表示していたため
